### PR TITLE
Set mdpi / @1x as baseline

### DIFF
--- a/export_assets_to_android_ios.jsx
+++ b/export_assets_to_android_ios.jsx
@@ -20,27 +20,27 @@ var selectedExportOptions = {};
 var androidExportOptions = [
     {
         name: "mdpi",
-        scaleFactor: 50,
-        type: "android"
-    },
-    {
-        name: "hdpi",
-        scaleFactor: 75,
-        type: "android"
-    },
-    {
-        name: "xhdpi",
         scaleFactor: 100,
         type: "android"
     },
     {
-        name: "xxhdpi",
+        name: "hdpi",
         scaleFactor: 150,
         type: "android"
     },
     {
-        name: "xxxhdpi",
+        name: "xhdpi",
         scaleFactor: 200,
+        type: "android"
+    },
+    {
+        name: "xxhdpi",
+        scaleFactor: 300,
+        type: "android"
+    },
+    {
+        name: "xxxhdpi",
+        scaleFactor: 400,
         type: "android"
     }
 ];
@@ -48,17 +48,17 @@ var androidExportOptions = [
 var iosExportOptions = [
     {
         name: "",
-        scaleFactor: 50,
-        type: "ios"
-    },
-    {
-        name: "@2x",
         scaleFactor: 100,
         type: "ios"
     },
     {
+        name: "@2x",
+        scaleFactor: 200,
+        type: "ios"
+    },
+    {
         name: "@3x",
-        scaleFactor: 150,
+        scaleFactor: 300,
         type: "ios"
     }
 ];


### PR DESCRIPTION
Set `mdpi`/`@1x` as baseline (scaleFactor: 100) instead of `hdpi`/`@2x`.
Designing at x1 is the best practice for scalable design. (see: https://medium.com/shyp-design/design-at-1x-its-a-fact-249c5b896536) 