### PR TITLE
Add Android folder to path

### DIFF
--- a/export_assets_to_android_ios.jsx
+++ b/export_assets_to_android_ios.jsx
@@ -97,7 +97,7 @@ if(document && folder) {
 function exportToFile(scaleFactor, resIdentifier, os) {
     var i, ab, file, options, expFolder;
     if(os === "android")
-        expFolder = new Folder(folder.fsName + "/drawable-" + resIdentifier);
+        expFolder = new Folder(folder.fsName + "/Android/drawable-" + resIdentifier);
     else if(os === "ios")
         expFolder = new Folder(folder.fsName + "/iOS");
 


### PR DESCRIPTION
This is complementary to the already existing iOS folder, as well, when doing multi-platform development (Nativescript), this allows one step copy and paste into the assets folder.