### PR TITLE
Checked by Default

### DIFF
--- a/export_assets_to_android_ios.jsx
+++ b/export_assets_to_android_ios.jsx
@@ -134,6 +134,7 @@ function createSelectionPanel(name, array, parent) {
     for(var i = 0; i < array.length;  i++) {
         var cb = panel.add("checkbox", undefined, "\u00A0" + array[i].name);
         cb.item = array[i];
+	cb.value = true;
         cb.onClick = function() {
             if(this.value) {
                 selectedExportOptions[this.item.name] = this.item;


### PR DESCRIPTION
Check all of the options by default, to prevent having to tick each item every time assets are exported.